### PR TITLE
Better handling of expand[] param

### DIFF
--- a/lib/mondo.js
+++ b/lib/mondo.js
@@ -120,6 +120,9 @@
     options.headers = options.headers || {}
     options.headers.client = 'NodeMondo-v' + version
     options.method = options.method || 'GET'
+    options.qsStringifyOptions = {
+      arrayFormat: 'brackets'
+    }
 
     if (typeof Promise === 'undefined') {
       if (!fn) {
@@ -300,6 +303,7 @@
    * @param {object|string} params Query object
    * If passed as a string, used as account_id
    * @param {string} params.account_id Account id
+   * @param {array|string} [params.expand] Properties to expand (merchant)
    * @param {date|string} [params.since] Date after which to show results (Date object or ISO string)
    * @param {date|string} [params.before] Date before which to show results (Date object or ISO string)
    * @param {int} [params.limit] Max number of transactions to return (100 max)
@@ -328,6 +332,10 @@
         account_id: params
       }
     }
+    if (params && params.expand && typeof params.expand === 'string') {
+      params.expand = [params.expand]
+    }
+
     var options = {
       uri: methodPaths.transactions,
       qs: params
@@ -340,7 +348,7 @@
    * @static
    * @param {object|String} params Transaction params
    * @param {string} params.transaction_id Transaction ID
-   * @param {string} [params.expand] Property to expand (merchant)
+   * @param {array|string} [params.expand] Properties to expand (merchant)
    * @param {string} access_token Access token
    * @param {function} [fn] Callback function
    * @return {object} Response value
@@ -367,9 +375,8 @@
       transaction_id = params.transaction_id
       delete params.transaction_id
     }
-    if (params && params.expand) {
-      params['expand[]'] = params.expand
-      delete params.expand
+    if (params && params.expand && typeof params.expand === 'string') {
+      params.expand = [params.expand]
     }
 
     var options = {

--- a/spec/unit/mondo.unit.spec.js
+++ b/spec/unit/mondo.unit.spec.js
@@ -194,33 +194,40 @@ describe('Mondo unit tests', function () {
         transKnocker({ limit: 10 })
         transKnocker({ since: /\d\d\d\d-\d\d-\d\dT\d\d/ })
         transKnocker({ before: /\d\d\d\d-\d\d-\d\dT\d\d/ })
+        transKnocker({ 'expand[]': 'merchant' })
       }
 
       beforeEach(function () {
         transactionsNock()
       })
-      it('should send correct balance request', function (done) {
+      it('should send correct transactions request', function (done) {
         mondo.transactions(mondargs.account_id, mondargs.access_token).then(testSuccess(done))
       })
-      it('should send correct balance request when using callback', function (done) {
+      it('should send correct transactions request when using callback', function (done) {
         mondo.transactions(mondargs.account_id, mondargs.access_token, testSuccess(done))
       })
-      it('should send correct balance request with limit', function (done) {
+      it('should send correct transactions request with limit', function (done) {
         mondo.transactions({
           account_id: mondargs.account_id,
           limit: 10
         }, mondargs.access_token).then(testSuccess(done))
       })
-      it('should send correct balance request with ISO date string', function (done) {
+      it('should send correct transactions request with ISO date string', function (done) {
         mondo.transactions({
           account_id: mondargs.account_id,
           since: '2015-11-10T23:00:00Z'
         }, mondargs.access_token).then(testSuccess(done))
       })
-      it('should send correct balance request with date object', function (done) {
+      it('should send correct transactions request with date object', function (done) {
         mondo.transactions({
           account_id: mondargs.account_id,
           before: new Date()
+        }, mondargs.access_token).then(testSuccess(done))
+      })
+      it('should send correct transactions request when expand param passed', function (done) {
+        mondo.transactions({
+          account_id: mondargs.account_id,
+          expand: 'merchant'
         }, mondargs.access_token).then(testSuccess(done))
       })
     })


### PR DESCRIPTION
Neater approach of passing expand parameter to `qs`, using `qsStringifyOptions`.
Also allow the expand parameter on `transactions` requests, which is undocumented
but supported.